### PR TITLE
Fixed CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 i.sethclossman.com
-=======
-i.sethclossman.com
->>>>>>> origin/master


### PR DESCRIPTION
For some reason on the last push, the merge information went into the CNAME file, so this just removed everything except for what needed to be here.
